### PR TITLE
Fixing graph import and renaming DM mortality variable

### DIFF
--- a/analysis/graphs_dm.do
+++ b/analysis/graphs_dm.do
@@ -11,7 +11,7 @@ cap log using ./logs/graphs_dm.log, replace
 foreach v in hba1c systolic_bp {
     * Ethnicity
     clear 
-    import delimited using ./output/measures/dm/measure_dm_`v'_ethnicity_rate.csv
+    import delimited using ./output/measures/dm/measure_dm_`v'_ethnicity_rate.csv, numericcols(4)
     * Generate rate per 100,000
     gen rate = value*100000 
     * Format date
@@ -36,7 +36,7 @@ foreach v in hba1c systolic_bp {
     graph export ./output/line_dm_ethnic_`v'.eps, as(eps) replace
     * IMD
     clear 
-    import delimited using ./output/measures/dm/measure_dm_`v'_imd_rate.csv
+    import delimited using ./output/measures/dm/measure_dm_`v'_imd_rate.csv, numericcols(4)
     * Generate rate per 100,000
     gen rate = value*100000 
     * Format date
@@ -65,7 +65,7 @@ foreach v in hba1c systolic_bp {
 foreach v in primary any /*emergency*/ {
     * Ethnicity - Type 1 DM
     clear 
-    import delimited using ./output/measures/dm/measure_dm_t1_`v'_ethnicity_rate.csv
+    import delimited using ./output/measures/dm/measure_dm_t1_`v'_ethnicity_rate.csv, numericcols(4)
     * Generate rate per 100,000
     gen rate = value*100000 
     * Format date
@@ -90,7 +90,7 @@ foreach v in primary any /*emergency*/ {
     graph export ./output/line_dm_ethnic_t1_`v'.eps, as(eps) replace
     * IMD - type 1 DM
     clear 
-    import delimited using ./output/measures/dm/measure_dm_t1_`v'_imd_rate.csv
+    import delimited using ./output/measures/dm/measure_dm_t1_`v'_imd_rate.csv, numericcols(4)
     * Generate rate per 100,000
     gen rate = value*100000 
     * Format date

--- a/analysis/graphs_resp.do
+++ b/analysis/graphs_resp.do
@@ -18,7 +18,7 @@ forvalues i=1/2 {
         local this_other :word `j' of `other'
     * Ethnicity
     clear 
-    import delimited using "./output/measures/resp/measure_`this_outcome'_`this_strata'_ethnicity_rate.csv"
+    import delimited using "./output/measures/resp/measure_`this_outcome'_`this_strata'_ethnicity_rate.csv", numericcols(4)
     * Generate rate per 100,000
     gen rate = value*100000 
     * Format date
@@ -43,7 +43,7 @@ forvalues i=1/2 {
     graph export ./output/line_resp_ethnic_`this_outcome'_`this_strata'.eps, as(eps) replace
     * IMD
     clear 
-    import delimited using "./output/measures/resp/measure_`this_outcome'_`this_strata'_imd_rate.csv"
+    import delimited using "./output/measures/resp/measure_`this_outcome'_`this_strata'_imd_rate.csv", numericcols(4)
     * Generate rate per 100,000
     gen rate = value*100000 
     * Format date

--- a/analysis/study_definition_mortality.py
+++ b/analysis/study_definition_mortality.py
@@ -123,7 +123,7 @@ study = StudyDefinition(
             },
         ),
     # Mortality - Diabetes - currently only have DM keto codes
-    dm_mortality=patients.with_these_codes_on_death_certificate(
+    keto_mortality=patients.with_these_codes_on_death_certificate(
         dm_keto_icd_codes,
         between=["index_date", "last_day_of_month(index_date)"],
         returning="binary_flag",
@@ -198,8 +198,8 @@ study = StudyDefinition(
 # Currently rates all for general population - not any subpopulations..
 measures = [
     Measure(
-        id="dm_mortality_ethnic_rate",
-        numerator="dm_mortality",
+        id="keto_mortality_ethnic_rate",
+        numerator="keto_mortality",
         denominator="population",
         group_by=["ethnicity"],
     ),
@@ -258,8 +258,8 @@ measures = [
         group_by=["ethnicity"],
     ),
     Measure(
-        id="dm_mortality_imd_rate",
-        numerator="dm_mortality",
+        id="keto_mortality_imd_rate",
+        numerator="keto_mortality",
         denominator="population",
         group_by=["imd"],
     ),


### PR DESCRIPTION
I had to do a small fix to the stata do files as it failed after the last merge. It failed because the rate value variable in the imported file was long, so rate was imported as string, so I have forced all scripts to import the rate value as numeric. 

I've also updated the dm_mortality variable to keto_mortality as suggested in the previous pull request.